### PR TITLE
Fix Vercel deployment: remove functions config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
-    "functions": {
-        "api/app.py": {
-          "maxDuration": 60
-        }
-    },
     "rewrites": [
         { "source": "/(.*)", "destination": "/api/app" }
-    ],
-    "outputDirectory": "tmp"
+    ]
 }


### PR DESCRIPTION
Deploy to vercel nowadays shows:
> [!CAUTION]
> The pattern "api/app.py" defined in `functions` doesn't match any Serverless Functions inside the `api` directory.

Vercel automatically detects api/app.py with Flask app. The functions pattern should only be used for configuring existing functions, not defining them. This fixes the 'unmatched function pattern' error.